### PR TITLE
Fix#4 Add decode part: only draft version

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -1,7 +1,9 @@
 package org.jabref.logic.importer.fileformat;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.PushbackReader;
 import java.io.Reader;
 import java.io.StringWriter;
@@ -624,6 +626,28 @@ public class BibtexParser implements Parser {
                     entry.addKeyword(content, importFormatPreferences.bibEntryPreferences().getKeywordSeparator());
                 }
             } else {
+                //TODO: change content here?
+                if(field.getName().length() > 10 && field.getName().substring(0, 10).equals("bdsk-file-")) {
+                    String newContent = "";
+                    try {
+                        // Create a process for the base64 -D | plutil -p - command
+                        ProcessBuilder processBuilder = new ProcessBuilder("bash", "-c", "echo \"" + content + "\" | base64 -D | plutil -p -");
+
+                        Process process = processBuilder.start();
+
+                        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+                        String line;
+                        while ((line = reader.readLine()) != null) {
+                            newContent += line;
+                        }
+                        int exitCode = process.waitFor();
+
+                    } catch (IOException | InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                    content = newContent;
+                }
                 entry.setField(field, content);
             }
         }


### PR DESCRIPTION
It works, although it's really ugly:(

<img width="537" alt="image" src="https://github.com/Frequinzy/jabref/assets/64673408/a35b220c-8d8f-4c87-92af-325e476e8f6c">

As the picture shows, the bdsk-file-1 field changes from "YnBsaXN0MDDSAQIDBFxyZWxhdGl2ZVBhdGhZYWxpYXNEYXRhXxAbLi4vRG93bmxvYWRzLzIzMDkuMDY5MzIucGRmTxEBUgAAAAABUgACAAAMTWFjaW50b3NoIEhEAAAAAAAAAAAAAAAAAAAA4O/yLkJEAAH/////DjIzMDkuMDY5MzIucGRmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP/////hKRjCAAAAAAAAAAAAAQACAAAKIGN1AAAAAAAAAAAAAAAAAAlEb3dubG9hZHMAAAIAKy86VXNlcnM6Y2hyaXN0b3BoczpEb3dubG9hZHM6MjMwOS4wNjkzMi5wZGYAAA4AHgAOADIAMwAwADkALgAwADYAOQAzADIALgBwAGQAZgAPABoADABNAGEAYwBpAG4AdABvAHMAaAAgAEgARAASAClVc2Vycy9jaHJpc3RvcGhzL0Rvd25sb2Fkcy8yMzA5LjA2OTMyLnBkZgAAEwABLwAAFQACABH//wAAAAgADQAaACQAQgAAAAAAAAIBAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAGY" to right-decoded content.
